### PR TITLE
Fixed input validation for chain rm

### DIFF
--- a/src/lib-cli/handlers/chain.ts
+++ b/src/lib-cli/handlers/chain.ts
@@ -148,9 +148,9 @@ const commands: Commands = {
         requestMessage: "Select config to remove:",
         validate: (input: string) => {
           const config = getCLIChainConfigByName(input);
-          if (config) {
+          if (!config) {
             console.log();
-            console.log(chalk.red("Config already exists with that name"));
+            console.log(chalk.red(`Config ${input} not found`));
             return false;
           }
 


### PR DESCRIPTION
- Fixed the first input validation for `chain rm`, the user should no longer be prompted when inputting the name of a config to remove