### PR TITLE
Updates for Galileo-2 Chain Configs

### DIFF
--- a/src/andr-js/chainConfigs/configs.json
+++ b/src/andr-js/chainConfigs/configs.json
@@ -47,11 +47,17 @@
     "registryAddress": "andr14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9shptkql",
     "addressPrefix": "andr",
     "defaultFee": "0.025uandr",
-    "blockExplorerTxPages": ["https://ping.wildsage.io/Andromeda/tx/${txHash}"],
-    "blockExplorerAddressPages": [
-      "https://ping.wildsage.io/Andromeda/account/${address}"
+    "blockExplorerTxPages": [
+      "https://testnet-ping.wildsage.io/andromeda/tx/${txHash}"
     ],
-    "chainType": "testnet"
+    "blockExplorerAddressPages": [
+      "https://testnet-ping.wildsage.io/andromeda/account/${address}"
+    ],
+    "chainType": "testnet",
+    "iconUrl": {
+      "sm": "https://testnet-ping.wildsage.io/logos/andromeda.png",
+      "lg": "https://testnet-ping.wildsage.io/logos/andromeda.png"
+    }
   },
   {
     "name": "pisco1",


### PR DESCRIPTION
## Purpose
To resolve issues with outdated chain configurations for Galileo-2 testnet.

## Implementation
Setup new block explorer address (was changed 09/28/22)
Added Temporary Icon URL (using same for Small and Large)

## Testing
None done, but will be performing in FE tests after update

## Notes
An alternate RPC endpoint is: https://rpc-andromeda-testnet.cereslabs.io/
An alternate LCD endpoint is: https://lcd-andromeda-testnet.cereslabs.io/swagger/

## Next Steps
Recommend an updated icon for mapping iconURL (to be used pre-gecko and post)