### PR TITLE
#CU-2wnb9rb | Initialization Hotfix

### DIFF
--- a/src/lib-cli/handlers/wallets.ts
+++ b/src/lib-cli/handlers/wallets.ts
@@ -15,6 +15,7 @@ const STORAGE_FILE = "wallets.json";
  */
 export async function loadWallets() {
   try {
+    if (!storage.storageFileExists(STORAGE_FILE)) return;
     const savedWalletsData = storage.loadStorageFile(STORAGE_FILE);
     try {
       const savedWallets = JSON.parse(savedWalletsData.toString());


### PR DESCRIPTION
# Motivation

If the user had not started the CLI before the `wallets.json` config file would not exist and an error would be printed.

# Implementation

Added a check for the files existance before loading wallets.

# Testing

N/A

# Notes

N/A

# Future work

N/A
