### PR TITLE
#CU-2wnba8v | Transaction History No Wallet

### DIFF
--- a/src/lib-cli/handlers/tx.ts
+++ b/src/lib-cli/handlers/tx.ts
@@ -42,6 +42,7 @@ export const commands: Commands = {
     color: chalk.rgb(23, 125, 90),
     description: "Gets a history of transactions for your current wallet",
     usage: "tx history",
+    disabled: () => typeof getCurrentWallet() === "undefined",
   },
 };
 
@@ -98,6 +99,8 @@ async function txAddressHandler(inputs: string[]) {
  */
 async function txHistoryHandler() {
   const wallet = getCurrentWallet();
+  if (!wallet) throw new Error("No wallet currently assigned");
+
   const walletAddr = await wallet.getFirstOfflineSigner(
     config.get("chain.chainId")
   );


### PR DESCRIPTION
# Motivation

If the user ran `tx history` with no wallet assigned an error would be thrown.

# Implementation

Disabled the `tx history` command when no wallet is assigned. Furthermore a check was added to the handler to ensure a wallet is assigned and a more human readable error is thrown in this case.

# Testing

N/A

# Notes

N/A

# Future work

N/A
