### PR TITLE
Added name field to assets response

### DIFF
--- a/packages/andrjs/src/graphql/queries/tx.ts
+++ b/packages/andrjs/src/graphql/queries/tx.ts
@@ -255,6 +255,7 @@ export interface QueryAssetsResponse {
   assets: {
     address: string;
     adoType: string;
+    name?: string;
     appContract?: string;
     chainId: string;
     instantiateHash: string;
@@ -270,6 +271,7 @@ export const QUERY_ASSETS = gql`
     assets(walletAddress: $walletAddress, limit: $limit, offset: $offset) {
       address
       adoType
+      name
       appContract
       chainId
       instantiateHash


### PR DESCRIPTION
# Motivation
The assets query seems to be omissive of the field "name" and needs to be added.

# Implementation
Updated the GQL query for assets and requested the "name" field. And returned the assets response along with the name field.

# Testing
Tested gql assets CLI commands and they are working fine

# Notes
NA

# Future work
NA