### PR TITLE
Fixed directory structure in cli build

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,0 +1,33 @@
+<p>&nbsp;</p>
+<p align="center">
+<img src="https://github.com/andromedaprotocol/andromeda.js/blob/development/image/andromeda-js-logo.png" width=800>
+</p>
+
+## About
+
+The Andromeda.js repository contains three packages: 
+
+- [andrjs](https://github.com/andromedaprotocol/andromeda.js/tree/development/packages/andrjs): JavaScript SDK for writing applications that interact with the Andromeda ecosystem.
+- [cli](https://github.com/andromedaprotocol/andromeda.js/tree/development/packages/cli): Used to interact with the Andromeda ecosystem and any of the chains Andromeda is deployed on.
+- [gql](https://github.com/andromedaprotocol/andromeda.js/tree/development/packages/gql): GQL tool used to auto generate gql functions and hooks from gql schema using gql-codegen
+
+## PNPM
+
+We use pnpm to manage packages. Most of the commands for pnpm are same as npm but make sure you use `pnpm` (not `npm`).
+
+## How to Build
+ 
+ 1. Install dependencies by `pnpm i`.
+ 2. Each package has build function. To build all package run `npm run build` in root directory.
+ 3. To Build each package indepedently, make sure the dependencies are already build (they have `dist/` folder). Then go inside that package directory and run `npm run build`.
+
+ ## Publish
+
+ 1. Commit your changes
+ 2. Run `pnpm changeset` in root directory
+ 3. Select the packages changed. All packages are linked using `fixed` config in `.changesets/config.json` so all will be bumped but make sure you specify correct packages
+ 4. Run `pnpm changeset version` and choose correct version.
+ 5. Add commit message and tag for the new version with proper messages.
+
+Now packages are ready for publish. Use `pnpm publish` to publish them to npm. Good Luck!
+

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -9,8 +9,7 @@
     "lib": [
       "esnext"
     ],
-    "baseUrl": "./src",
-    "rootDir": "."
+    "baseUrl": "./src"
   },
   "include": [
     "src/**/*.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ importers:
   packages/andrjs:
     dependencies:
       '@andromedaprotocol/gql':
-        specifier: workspace:../gql
+        specifier: workspace:*
         version: link:../gql
       '@archwayhq/arch3.js':
         specifier: ^0.4.0
@@ -117,7 +117,7 @@ importers:
   packages/cli:
     dependencies:
       '@andromedaprotocol/andromeda.js':
-        specifier: workspace:../andrjs
+        specifier: workspace:*
         version: link:../andrjs
       '@cosmjs/amino':
         specifier: ^0.31.1


### PR DESCRIPTION
Because of rootDir set as '.' instead of './', cli build was nested inside `src` folder which caused `bin` path in package.json to fail.
This PR is minor fix to rootDir config for cli package.

## Additional Updates

Added DEVELOPER.md file which contains instruction related to package versioning and publish