### PR TITLE
Resolve --help sub-cmd list

### DIFF
--- a/packages/cli/src/handlers/utils.ts
+++ b/packages/cli/src/handlers/utils.ts
@@ -97,8 +97,9 @@ export async function handle(
       log(pc.red("Command disabled"));
       return;
     }
-    if (flags["help"] && (commandInput.length === 0 || cmd.inputs)) {
-      await printCommandHelp(cmd, commands);
+    if (flags["--help"] && (commandInput.length === 0 || cmd.inputs)) {
+      //await printCommandHelp(cmd, commands);
+      await listCommands(commands, prefix);
       return;
     }
 


### PR DESCRIPTION
## Motivation
Resolving conflicts with the --help flag showing base menu options and not the sub commands for the base cmd.

## Related Issue
Resolving errors noted in Issue #87 

## Changes Applied
- Altered condition value to --help (not "help)
- Updated the printCommandHelp to listCommands

## Testing
Tested against each of the base commands

## Future Work
Future enhancement of the --help flag would present autogenerated links to documentation