### PR TITLE
Disabling user Command

### DIFF
--- a/packages/cli/src/cmd.ts
+++ b/packages/cli/src/cmd.ts
@@ -113,7 +113,9 @@ export const baseCommands: Commands = {
     description: "Manage user",
     color: pc.blue,
     usage: "user <cmd>",
-    disabled: () => typeof State.wallets.currentWallet === "undefined",
+// Applying the disabled state to the user command until the user command is implemented in AMP.
+    // disabled: () => typeof State.wallets.currentWallet === "undefined",
+    disabled: () => true,
   },
 };
 


### PR DESCRIPTION
## Motivation
Additional testing needs to be run against the username portion of the core contracts and AMP integrations. For this reason the `user` command is being disabled from the CLI command options until the time that it is in a confirmed usable state.

## Integration
- Applied an always true value to the disabled state to be pulled once AMP user testing is fully implemented.

## Testing
- Confirmed command is disabled from use (including with args)
- Confirmed disabled command is not listed in the command listings for `help` command and error helpers.